### PR TITLE
Add LLPrintListeSuper wrapper to combine printing functions

### DIFF
--- a/28/28.mod
+++ b/28/28.mod
@@ -1,4 +1,4 @@
-Public Function LLPrintListe(frm As Form, _
+Public Function LLPrintListe2800(frm As Form, _
                              LL1 As ListLabel.ListLabel, _
                              BelegID As Long, _
                              Mode As Integer, _
@@ -568,7 +568,7 @@ Public Function LLPrintListe(frm As Form, _
                             
                         LL1.LlPrintEnd 0
 
-                        LLPrintListe = glRet
+                        LLPrintListe2800 = glRet
                         
                         If Not SammelDruck Then
 
@@ -650,7 +650,7 @@ Public Function LLPrintListe(frm As Form, _
                         
                         LL1.LlPrintEnd 0
 
-                        LLPrintListe = LL_ERR_USER_ABORTED
+                        LLPrintListe2800 = LL_ERR_USER_ABORTED
                             
                         glRet = LL1.LlPreviewDeleteFiles(ArbeitsplatzPfad & "\SP52800.LL", "")
                             
@@ -1159,7 +1159,7 @@ Public Function LLPrintListe(frm As Form, _
   
 Fehler:
    
-    LLPrintListe = Err.number
+    LLPrintListe2800 = Err.number
 
     If Mode = 1 Or Mode = 4 Then                                           'IL 07.11.2024 , Ver.: 6.7.101 :  Ablage hinzugefügt
 
@@ -1180,9 +1180,9 @@ Fehler:
     End If
 
     If glRet <> 0 Then
-        Call FehlerErklärung("SP52800B", "LLPrintListe LL-Fehler: " & glRet & ", j = " & j)
+        Call FehlerErklärung("SP52800B", "LLPrintListe2800 LL-Fehler: " & glRet & ", j = " & j)
     Else
-        Call FehlerErklärung("SP52800B", "LLPrintListe")
+        Call FehlerErklärung("SP52800B", "LLPrintListe2800")
     End If
 
 End Function

--- a/28/64.mod
+++ b/28/64.mod
@@ -1,4 +1,4 @@
-Public Function LLPrintListe(frm As Form, _
+Public Function LLPrintListe5640(frm As Form, _
                              LL1 As ListLabel.ListLabel, _
                              BelegID As Long, _
                              Mode As Integer, _
@@ -505,7 +505,7 @@ Public Function LLPrintListe(frm As Form, _
                 If glRet = LL_ERR_USER_ABORTED Then
 
                     LL1.LlPrintEnd 0                    'DH, 11.07.2013, 6.2.100, Bei Abbruch den Druckjob beenden
-                    LLPrintListe = LL_ERR_USER_ABORTED
+                    LLPrintListe5640 = LL_ERR_USER_ABORTED
 
                     If Not SammelDruck Then
 
@@ -844,7 +844,7 @@ Exit_PrintListe:
   
 Fehler:
    
-    LLPrintListe = Err.number
+    LLPrintListe5640 = Err.number
 
     If Mode = 1 Then
         If Not SammelDruck Then
@@ -859,7 +859,7 @@ Fehler:
 
     Debug.Print "LL Fehler: " & glRet
 
-    Call FehlerErklärung("SP56000B", "LLPrintListe()")
+    Call FehlerErklärung("SP56000B", "LLPrintListe5640()")
     GoSub Exit_PrintListe
 
 End Function

--- a/28/LLPrintListeSuper.mod
+++ b/28/LLPrintListeSuper.mod
@@ -1,0 +1,18 @@
+Public Function LLPrintListeSuper(frm As Form, _
+                                  LL1 As ListLabel.ListLabel, _
+                                  BelegID As Long, _
+                                  Mode As Integer, _
+                                  Optional tmp As Boolean, _
+                                  Optional Save As Boolean, _
+                                  Optional SammelDruck As Boolean, _
+                                  Optional Bereich As Integer = 2800) As Long
+    'Wrapper that dispatches printing to the correct module based on Bereich.
+    Select Case Bereich
+        Case 2800
+            LLPrintListeSuper = LLPrintListe2800(frm, LL1, BelegID, Mode, tmp, Save, SammelDruck)
+        Case 5640
+            LLPrintListeSuper = LLPrintListe5640(frm, LL1, BelegID, Mode, tmp, Save, SammelDruck)
+        Case Else
+            LLPrintListeSuper = -1
+    End Select
+End Function


### PR DESCRIPTION
## Summary
- Rename existing LLPrintListe implementations to LLPrintListe2800 and LLPrintListe5640
- Introduce LLPrintListeSuper wrapper dispatching to the correct implementation

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6891f8ddcd588323a5fe4d8765be9657